### PR TITLE
 Set Default Value for `revealed` Field in Assignment Schema

### DIFF
--- a/server/src/models/assignment.ts
+++ b/server/src/models/assignment.ts
@@ -5,7 +5,8 @@ import { AssignmentInterface } from "../types/assignment.interface";
 const assignmentSchema = new Schema<AssignmentInterface>({
   event: { type: Schema.Types.ObjectId, ref: "Event", required: true },
   giver: { type: String, required: true },
-  receiver: { type: String, required: true }
+  receiver: { type: String, required: true },
+  revealed: { type: Boolean, default: false}
 });
 
 const AssignmentModel = model<AssignmentInterface>("Assignment", assignmentSchema);

--- a/server/src/services/eventService.ts
+++ b/server/src/services/eventService.ts
@@ -31,7 +31,8 @@ export const createEvent = async (eventData: any) => {
     const assignments = secretSantaPairs.map(pair => ({
         event: savedEvent._id,
         giver: pair.giver,
-        receiver: pair.receiver
+        receiver: pair.receiver,
+        revealed: false
     }));
 
     await AssignmentModel.insertMany(assignments);

--- a/server/src/types/assignment.interface.ts
+++ b/server/src/types/assignment.interface.ts
@@ -4,6 +4,7 @@ export interface Assignment {
   event: Types.ObjectId; 
   giver: string; 
   receiver: string; 
+  revealed: Boolean;
 }
 
 export interface AssignmentInterface


### PR DESCRIPTION

### **Description:**
This pull request creates a filed `revealed` to know if the pair has been seen by the giver. It sets the default value of the `revealed` field to `false` in the `Assignment` schema. The change ensures that when a new assignment is created without explicitly setting the `revealed` field, it will automatically default to `false`.

I also updated the `CreateEvent` method in the service to insert the revealed field when creating assignements

#37